### PR TITLE
feat: タスク管理API (CRUD) の実装

### DIFF
--- a/backend/app/controllers/api/v1/tasks_controller.rb
+++ b/backend/app/controllers/api/v1/tasks_controller.rb
@@ -1,0 +1,45 @@
+class Api::V1::TasksController < ApplicationController
+  before_action :set_task, only: [:show, :update, :destroy]
+
+  def index
+    @tasks = Task.all
+    render json: @tasks
+  end
+
+  def show
+    render json: @task
+  end
+
+  def create
+    @task = Task.new(task_params)
+
+    if @task.save
+      render json: @task, status: :created
+    else
+      render json: @task.errors, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @task.update(task_params)
+      render json: @task
+    else
+      render json: @task.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @task.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_task
+    @task = Task.find(params[:id])
+  end
+
+  def task_params
+    params.require(:task).permit(:title, :description, :due_date, :status)
+  end
+end

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_response
+
+  private
+
+  def render_not_found_response(exception)
+    render json: { error: exception.message }, status: :not_found
+  end
 end

--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -1,0 +1,4 @@
+class Task < ApplicationRecord
+  enum status: { not_started: 0, in_progress: 1, completed: 2 }
+  validates :title, presence: true
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,5 +1,12 @@
 Rails.application.routes.draw do
   resources :projects, only: [:index, :show, :create, :update, :destroy]
+
+  namespace :api do
+    namespace :v1 do
+      resources :tasks, only: [:index, :show, :create, :update, :destroy]
+    end
+  end
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/backend/db/migrate/20250812102844_create_tasks.rb
+++ b/backend/db/migrate/20250812102844_create_tasks.rb
@@ -1,0 +1,12 @@
+class CreateTasks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tasks do |t|
+      t.string :title
+      t.text :description
+      t.date :due_date
+      t.integer :status
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_12_005430) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_12_102844) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_12_005430) do
     t.string "name"
     t.text "description"
     t.jsonb "technical_context"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.date "due_date"
+    t.integer "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/backend/spec/factories/tasks.rb
+++ b/backend/spec/factories/tasks.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :task do
+    title { Faker::Lorem.sentence }
+    description { Faker::Lorem.paragraph }
+    due_date { Faker::Date.forward(days: 30) }
+    status { Task.statuses.keys.sample }
+  end
+end

--- a/backend/spec/models/task_spec.rb
+++ b/backend/spec/models/task_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/requests/api/v1/tasks_spec.rb
+++ b/backend/spec/requests/api/v1/tasks_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Tasks", type: :request do
+  let!(:task) { create(:task) } # FactoryBotを使用
+
+  describe "GET /api/v1/tasks" do
+    it "returns a list of tasks" do
+      get api_v1_tasks_path
+      expect(response).to have_http_status(:ok)
+      expect(json_response.size).to eq(1)
+      expect(json_response.first['title']).to eq(task.title)
+    end
+  end
+
+  describe "GET /api/v1/tasks/:id" do
+    it "returns a single task" do
+      get api_v1_task_path(task)
+      expect(response).to have_http_status(:ok)
+      expect(json_response['title']).to eq(task.title)
+    end
+
+    it "returns not found if task does not exist" do
+      get api_v1_task_path(id: 999)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST /api/v1/tasks" do
+    context "with valid parameters" do
+      it "creates a new task" do
+        task_params = attributes_for(:task)
+        expect {
+          post api_v1_tasks_path, params: { task: task_params }
+        }.to change(Task, :count).by(1)
+        expect(response).to have_http_status(:created)
+        expect(json_response['title']).to eq(task_params[:title])
+      end
+    end
+
+    context "with invalid parameters" do
+      it "does not create a new task" do
+        task_params = attributes_for(:task, title: nil) # titleをnilにしてバリデーションエラーを発生させる
+        expect {
+          post api_v1_tasks_path, params: { task: task_params }
+        }.to_not change(Task, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "PUT /api/v1/tasks/:id" do
+    context "with valid parameters" do
+      it "updates the task" do
+        new_title = "Updated Task Title"
+        put api_v1_task_path(task), params: { task: { title: new_title } }
+        expect(response).to have_http_status(:ok)
+        expect(json_response['title']).to eq(new_title)
+        expect(task.reload.title).to eq(new_title)
+      end
+    end
+
+    context "with invalid parameters" do
+      it "does not update the task" do
+        put api_v1_task_path(task), params: { task: { title: nil } }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(task.reload.title).to_not be_nil
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/tasks/:id" do
+    it "deletes the task" do
+      expect {
+        delete api_v1_task_path(task)
+      }.to change(Task, :count).by(-1)
+      expect(response).to have_http_status(:no_content)
+      expect { task.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  # ヘルパーメソッド
+  def json_response
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
タスク管理のためのCRUD APIを実装しました。

## 実装内容
- Taskモデルの定義 (title, description, due_date, status)
- データベースマイグレーションの実行
- APIルーティングの設定 (/api/v1/tasks)
- TasksControllerの実装 (index, show, create, update, destroy)
- ActiveRecord::RecordNotFoundの例外ハンドリング
- Taskモデルのバリデーション (titleのpresence)
- RSpecによるAPIテストの追加